### PR TITLE
Add support for post-6.43 authentication

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -29,6 +29,12 @@ const CONNECTION = {
   , ERROR: 32
 };
 
+const AUTH_MODE = {
+  PRE_6_43: 'pre-6.43',
+  POST_6_43: 'default',
+  DEFAULT: 'default',
+};
+
 const CHANNEL = {
   NONE: 0
   , OPEN: 1
@@ -51,4 +57,4 @@ const EVENT = {
   , DATA: 'data'  // This is an artifical event, not one from the API
 };
 
-export {STRING_TYPE, DEBUG, CONNECTION, CHANNEL, EVENT, connectionLabels};
+export {STRING_TYPE, DEBUG, CONNECTION, CHANNEL, EVENT, AUTH_MODE, connectionLabels};


### PR DESCRIPTION
By default, post-6.43 auth will be used. The older auth mechanism can still be used by setting the `MikroNode` instance's `authMode`:

```js
let c = new MikroNode(...);
c.authMode = MikroNode.AUTH_MODE.PRE_6_43;
// continue as normal
```