### PR TITLE
Retain entire record as leftover in decodePackets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mikronode",
   "description": "MikroTik API client for NodeJS",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "license": "MIT",
   "author": "Brandon Myers <trakkasure@gmail.com>",
   "scripts": {

--- a/src/Util.js
+++ b/src/Util.js
@@ -40,7 +40,6 @@ function encodeString(s, d) {
 function decodePackets(data) {
   if (!data.length) return [];
   const result = [];
-  let leftover;
   let idx = 0;
   let buf = [];
   // orig contains the original, encoded bytes of the record being decoded.
@@ -64,14 +63,13 @@ function decodePackets(data) {
     let end = idx + len;
     orig = Buffer.concat([orig, data.slice(rec_start, end)]);
     if(end > data.length) {
-      // record is incomplete, set leftover and quit the loop
-      leftover = orig;
+      // record is incomplete, quit the loop.
       break;
     }
     buf.push(data.slice(idx, end).toString('utf8'));
     idx += len;
   }
-  return [result, leftover];
+  return [result, orig];
 }
 
 function decodeLength(data, idx, b) {

--- a/src/index.js
+++ b/src/index.js
@@ -216,18 +216,19 @@ class SocketStream {
     // this is the stream reader/parser.
     // My poor stream parser
     this.data$.scan((/* @type Buffer */ last,/* @type Buffer */stream, i) => {
-      let buff = Buffer.concat([last, stream]), end = 0, idx = 0, packet;
+      let buff = Buffer.concat([last, stream]);
       this.debug >= DEBUG.DEBUG && console.log('Packet received: ', Buffer.from(stream).toString('base64'));
       this.debug >= DEBUG.DEBUG && last.length > 0 && console.log('Starting parse loop w/existing packet ', Buffer.from(last).toString('base64'));
       try {
         let [packets, leftover] = decodePackets(buff);
-        for(packet of packets) {
+        for(let packet of packets) {
           this.sentence$.next(packet);
         }
-        return leftover;
+        return leftover || Buffer.alloc(0);
       } catch(e) {
         e.message = `${e.message} - original buffer: ${buff.toString('base64')}`;
         this.sentence$.error(e);
+        return Buffer.alloc(0);
       }
     }, Buffer.from([]))
       .subscribe(e => this.debug >= DEBUG.DEBUG && e.length && console.log('Buffer leftover: ', Buffer.from(e).toString('base64')), this.closeSocket.bind(this), this.closeSocket.bind(this));


### PR DESCRIPTION
Previously, `leftover` would only include the last incomplete field, causing records that span multiple packets to turn into garbage.

This keeps track of the encoded original bytes in each record so that it can return them as leftover if it turns out the current record is incomplete.